### PR TITLE
Delete comment by comment_id rather than user_id

### DIFF
--- a/routes/api/posts.js
+++ b/routes/api/posts.js
@@ -230,8 +230,8 @@ router.delete('/comment/:id/:comment_id', auth, async (req, res) => {
 
     // Get remove index
     const removeIndex = post.comments
-      .map(comment => comment.user.toString())
-      .indexOf(req.user.id);
+      .map(comment => comment.id)
+      .indexOf(req.params.comment_id);
 
     post.comments.splice(removeIndex, 1);
 


### PR DESCRIPTION
> DELETE api/posts/comment/:id/:comment_id

This route is suppose to delete a comment by comment id 
But it actually deletes the first comment a certain user posted