### PR TITLE
Fixed date react-moment date bug

### DIFF
--- a/client/src/components/dashboard/Education.js
+++ b/client/src/components/dashboard/Education.js
@@ -1,6 +1,7 @@
 import React, { Fragment } from 'react';
 import PropTypes from 'prop-types';
 import Moment from 'react-moment';
+import moment from 'moment';
 import { connect } from 'react-redux';
 import { deleteEducation } from '../../actions/profile';
 
@@ -8,19 +9,19 @@ const Education = ({ education, deleteEducation }) => {
   const educations = education.map(edu => (
     <tr key={edu._id}>
       <td>{edu.school}</td>
-      <td className='hide-sm'>{edu.degree}</td>
+      <td className="hide-sm">{edu.degree}</td>
       <td>
-        <Moment format='YYYY/MM/DD'>{edu.from}</Moment> -{' '}
+        <Moment format="YYYY/MM/DD">{moment.utc(edu.from)}</Moment> -{' '}
         {edu.to === null ? (
           ' Now'
         ) : (
-          <Moment format='YYYY/MM/DD'>{edu.to}</Moment>
+          <Moment format="YYYY/MM/DD">{moment.utc(edu.to)}</Moment>
         )}
       </td>
       <td>
         <button
           onClick={() => deleteEducation(edu._id)}
-          className='btn btn-danger'
+          className="btn btn-danger"
         >
           Delete
         </button>
@@ -30,13 +31,13 @@ const Education = ({ education, deleteEducation }) => {
 
   return (
     <Fragment>
-      <h2 className='my-2'>Education Credentials</h2>
-      <table className='table'>
+      <h2 className="my-2">Education Credentials</h2>
+      <table className="table">
         <thead>
           <tr>
             <th>School</th>
-            <th className='hide-sm'>Degree</th>
-            <th className='hide-sm'>Years</th>
+            <th className="hide-sm">Degree</th>
+            <th className="hide-sm">Years</th>
             <th />
           </tr>
         </thead>

--- a/client/src/components/dashboard/Experience.js
+++ b/client/src/components/dashboard/Experience.js
@@ -1,6 +1,7 @@
 import React, { Fragment } from 'react';
 import PropTypes from 'prop-types';
 import Moment from 'react-moment';
+import moment from 'moment';
 import { connect } from 'react-redux';
 import { deleteExperience } from '../../actions/profile';
 
@@ -8,19 +9,19 @@ const Experience = ({ experience, deleteExperience }) => {
   const experiences = experience.map(exp => (
     <tr key={exp._id}>
       <td>{exp.company}</td>
-      <td className='hide-sm'>{exp.title}</td>
+      <td className="hide-sm">{exp.title}</td>
       <td>
-        <Moment format='YYYY/MM/DD'>{exp.from}</Moment> -{' '}
+        <Moment format="YYYY/MM/DD">{moment.utc(exp.from)}</Moment> -{' '}
         {exp.to === null ? (
           ' Now'
         ) : (
-          <Moment format='YYYY/MM/DD'>{exp.to}</Moment>
+          <Moment format="YYYY/MM/DD">{moment.utc(exp.to)}</Moment>
         )}
       </td>
       <td>
         <button
           onClick={() => deleteExperience(exp._id)}
-          className='btn btn-danger'
+          className="btn btn-danger"
         >
           Delete
         </button>
@@ -30,13 +31,13 @@ const Experience = ({ experience, deleteExperience }) => {
 
   return (
     <Fragment>
-      <h2 className='my-2'>Experience Credentials</h2>
-      <table className='table'>
+      <h2 className="my-2">Experience Credentials</h2>
+      <table className="table">
         <thead>
           <tr>
             <th>Company</th>
-            <th className='hide-sm'>Title</th>
-            <th className='hide-sm'>Years</th>
+            <th className="hide-sm">Title</th>
+            <th className="hide-sm">Years</th>
             <th />
           </tr>
         </thead>

--- a/client/src/components/profile/ProfileEducation.js
+++ b/client/src/components/profile/ProfileEducation.js
@@ -1,15 +1,16 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import Moment from 'react-moment';
+import moment from 'moment';
 
 const ProfileEducation = ({
   education: { school, degree, fieldofstudy, current, to, from, description }
 }) => (
   <div>
-    <h3 className='text-dark'>{school}</h3>
+    <h3 className="text-dark">{school}</h3>
     <p>
-      <Moment format='YYYY/MM/DD'>{from}</Moment> -{' '}
-      {!to ? ' Now' : <Moment format='YYYY/MM/DD'>{to}</Moment>}
+      <Moment format="YYYY/MM/DD">{moment.utc(from)}</Moment> -{' '}
+      {!to ? ' Now' : <Moment format="YYYY/MM/DD">{moment.utc(to)}</Moment>}
     </p>
     <p>
       <strong>Degree: </strong> {degree}

--- a/client/src/components/profile/ProfileExperience.js
+++ b/client/src/components/profile/ProfileExperience.js
@@ -1,15 +1,16 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import Moment from 'react-moment';
+import moment from 'moment';
 
 const ProfileExperience = ({
   experience: { company, title, location, current, to, from, description }
 }) => (
   <div>
-    <h3 className='text-dark'>{company}</h3>
+    <h3 className="text-dark">{company}</h3>
     <p>
-      <Moment format='YYYY/MM/DD'>{from}</Moment> -{' '}
-      {!to ? ' Now' : <Moment format='YYYY/MM/DD'>{to}</Moment>}
+      <Moment format="YYYY/MM/DD">{moment.utc(from)}</Moment> -{' '}
+      {!to ? ' Now' : <Moment format="YYYY/MM/DD">{moment.utc(to)}</Moment>}
     </p>
     <p>
       <strong>Position: </strong> {title}


### PR DESCRIPTION
The education and experience dates on the dashboard and profile pages were off by one day.

I passed in 01/01/90 into the Moment component, but 12/31/89 is rendered. This is what the React dev tools shows.

**children: "12/31/89"**
dateTime: Moment{…}
__proto__: {…}
**_d: Sun Dec 31 1989 16:00:00 GMT-0800 (Pacific Standard Time)**
_f: "YYYY-MM-DDTHH:mm:ss.SSSSZ"
**_i: "1990-01-01T00:00:00.000Z"**
_isAMomentObject: true
**_isUTC: false**
_isValid: true
_l: "en"
_locale: Locale{…}
_pf: {…}
_tzm: 0

**_i** shows that I did indeed pass in the right date and it is correctly saved in MongoDB, however **_d** is being rendered. After some research I've found that Moment parses and displays in local time and therefore we need to **ignore _d**.

I used **moment.utc()** to set it to utc format. This is the result and solution. Note that UTC is now set to true in the React dev tools.

**children: "01/01/90"**
dateTime: Moment{…}
__proto__: {…}
**_d: Sun Dec 31 1989 16:00:00 GMT-0800 (Pacific Standard Time)**
_f: "YYYY-MM-DDTHH:mm:ss.SSSSZ"
**_i: "1990-01-01T00:00:00.000Z"**
_isAMomentObject: true
**_isUTC: true**
_isValid: true
_locale: Locale{…}
_offset: 0
_pf: {…}
_tzm: 0

Apologies for any confusion, this is my first pull request.