### PR TITLE
Fix typechecking in ProfileExperience.js

### DIFF
--- a/client/src/components/profile/ProfileExperience.js
+++ b/client/src/components/profile/ProfileExperience.js
@@ -22,7 +22,7 @@ const ProfileExperience = ({
 );
 
 ProfileExperience.propTypes = {
-  experience: PropTypes.array.isRequired
+  experience: PropTypes.object.isRequired
 };
 
 export default ProfileExperience;


### PR DESCRIPTION
Fix typechecking in ProfileExperience component: Prop 'experience' of type 'object' supplied to 'ProfileExperience', but was declared type of 'array' by mistake.