### PR TITLE
Fix typechecking in ProfileEducation.js

### DIFF
--- a/client/src/components/profile/ProfileEducation.js
+++ b/client/src/components/profile/ProfileEducation.js
@@ -25,7 +25,7 @@ const ProfileEducation = ({
 );
 
 ProfileEducation.propTypes = {
-  education: PropTypes.array.isRequired
+  education: PropTypes.object.isRequired
 };
 
 export default ProfileEducation;


### PR DESCRIPTION
Fix typechecking in ProfileEducation component: Prop 'education' of type 'object' supplied to 'ProfileEducation', but was declared type of 'array' by mistake.