### PR TITLE
Update profile post route

### DIFF
--- a/routes/api/profile.js
+++ b/routes/api/profile.js
@@ -89,23 +89,12 @@ router.post(
     if (instagram) profileFields.social.instagram = instagram;
 
     try {
-      let profile = await Profile.findOne({ user: req.user.id });
-
-      if (profile) {
-        // Update
-        profile = await Profile.findOneAndUpdate(
-          { user: req.user.id },
-          { $set: profileFields },
-          { new: true }
-        );
-
-        return res.json(profile);
-      }
-
-      // Create
-      profile = new Profile(profileFields);
-
-      await profile.save();
+      // Using upsert option (creates new doc if no match is found):
+      let profile = await Profile.findOneAndUpdate(
+        { user: req.user.id },
+        { $set: profileFields },
+        { new: true, upsert: true }
+      );
       res.json(profile);
     } catch (err) {
       console.error(err.message);


### PR DESCRIPTION
Replaced the calls to findOne( ), findOneAndUpdate( ) and save( )  with a single call to findOneAndUpdate( ) with the 'upsert' option set to true (creates new doc if no match is found).