### PR TITLE
Add encodeURI function in github request options

### DIFF
--- a/routes/api/profile.js
+++ b/routes/api/profile.js
@@ -382,11 +382,11 @@ router.delete("/education/:edu_id", auth, async (req, res) => {
 router.get('/github/:username', (req, res) => {
   try {
     const options = {
-      uri: `https://api.github.com/users/${
+      uri: encodeURI(`https://api.github.com/users/${
         req.params.username
       }/repos?per_page=5&sort=created:asc&client_id=${config.get(
         'githubClientId'
-      )}&client_secret=${config.get('githubSecret')}`,
+      )}&client_secret=${config.get('githubSecret')}`),
       method: 'GET',
       headers: { 'user-agent': 'node.js' }
     };


### PR DESCRIPTION
I've got an 500 error instead of 404 when I typed unexisting github username with unescaped characters (in my case polish "ż" character) in user profile. What's more the whole app crashed. Adding encodeURI solves that problem.