### PR TITLE
Removed '/check' from Express Validator location

### DIFF
--- a/routes/api/profile.js
+++ b/routes/api/profile.js
@@ -3,7 +3,7 @@ const request = require('request');
 const config = require('config');
 const router = express.Router();
 const auth = require('../../middleware/auth');
-const { check, validationResult } = require('express-validator/check');
+const { check, validationResult } = require('express-validator');
 
 const Profile = require('../../models/Profile');
 const User = require('../../models/User');


### PR DESCRIPTION
`/check` is deprecated, so `require('express-validator')` is all that's necessary. 

It's written the same way in the code featured in the [documentation](https://express-validator.github.io/docs/) as well, as seen in the screenshot below:

<img width="839" alt="Screen Shot 2020-01-25 at 8 29 59 PM" src="https://user-images.githubusercontent.com/45137225/73129434-7dc44f00-3fb1-11ea-9793-a468fc5c2ff4.png">
