### PR TITLE
auth reducer set user: null

### DIFF
--- a/client/src/reducers/auth.js
+++ b/client/src/reducers/auth.js
@@ -46,7 +46,8 @@ export default function(state = initialState, action) {
         ...state,
         token: null,
         isAuthenticated: false,
-        loading: false
+        loading: false,
+        user: null
       };
     default:
       return state;


### PR DESCRIPTION
After actions as  "LOGOUT, ACCOUNT_DELETED:" user stays in state. Even though the info is not sensitive, better to clear out in state.