### PR TITLE
Requires to express-validator/check are deprecated

### DIFF
--- a/routes/api/auth.js
+++ b/routes/api/auth.js
@@ -4,7 +4,7 @@ const bcrypt = require('bcryptjs');
 const auth = require('../../middleware/auth');
 const jwt = require('jsonwebtoken');
 const config = require('config');
-const { check, validationResult } = require('express-validator/check');
+const { check, validationResult } = require('express-validator');
 
 const User = require('../../models/User');
 

--- a/routes/api/posts.js
+++ b/routes/api/posts.js
@@ -1,6 +1,6 @@
 const express = require('express');
 const router = express.Router();
-const { check, validationResult } = require('express-validator/check');
+const { check, validationResult } = require('express-validator');
 const auth = require('../../middleware/auth');
 
 const Post = require('../../models/Post');

--- a/routes/api/users.js
+++ b/routes/api/users.js
@@ -4,7 +4,7 @@ const gravatar = require('gravatar');
 const bcrypt = require('bcryptjs');
 const jwt = require('jsonwebtoken');
 const config = require('config');
-const { check, validationResult } = require('express-validator/check');
+const { check, validationResult } = require('express-validator');
 
 const User = require('../../models/User');
 


### PR DESCRIPTION
As mentioned the /check is deprecated and require("express-validator") is all that is needed.

You can see in the [Docs](https://express-validator.github.io/docs/) that they set it up the same way as well.  