### PR TITLE
Stricter private routing

### DIFF
--- a/client/src/components/routing/PrivateRoute.js
+++ b/client/src/components/routing/PrivateRoute.js
@@ -11,11 +11,7 @@ const PrivateRoute = ({
   <Route
     {...rest}
     render={props =>
-      !isAuthenticated && !loading ? (
-        <Redirect to='/login' />
-      ) : (
-        <Component {...props} />
-      )
+      isAuthenticated ? <Component {...props} /> : <Redirect to="/login" />
     }
   />
 );


### PR DESCRIPTION
Currently it is possible to visit a private route like /posts if the user is not authenticated.
No posts will show, but the expected behaviour is to be re-directed to /login.
This PR changes the conditional to be more strict.