### PR TITLE
Fix issues with social urls and skills array/string

### DIFF
--- a/client/src/components/profile-forms/EditProfile.js
+++ b/client/src/components/profile-forms/EditProfile.js
@@ -128,7 +128,7 @@ const EditProfile = ({
             type="text"
             placeholder="* Skills"
             name="skills"
-            value={Array.isArray(skills) ? skills.join(', ') : skills}
+            value={skills}
             onChange={onChange}
           />
           <small className="form-text">

--- a/client/src/components/profile-forms/EditProfile.js
+++ b/client/src/components/profile-forms/EditProfile.js
@@ -36,6 +36,9 @@ const EditProfile = ({
       for (const key in profile) {
         if (key in profileData) profileData[key] = profile[key];
       }
+      for (const key in profile.social) {
+        if (key in profileData) profileData[key] = profile.social[key];
+      }
       setFormData(profileData);
     }
   }, [loading, getCurrentProfile, profile]);

--- a/client/src/components/profile-forms/EditProfile.js
+++ b/client/src/components/profile-forms/EditProfile.js
@@ -128,7 +128,7 @@ const EditProfile = ({
             type="text"
             placeholder="* Skills"
             name="skills"
-            value={skills}
+            value={Array.isArray(skills) ? skills.join(', ') : skills}
             onChange={onChange}
           />
           <small className="form-text">

--- a/package-lock.json
+++ b/package-lock.json
@@ -9243,9 +9243,9 @@
       "integrity": "sha1-LRDAa9/TEuqXd2laTShDlFa3WUI="
     },
     "normalize-url": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-3.3.0.tgz",
-      "integrity": "sha512-U+JJi7duF1o+u2pynbp2zXDW2/PADgC30f0GsHZtRh+HOcXHnw137TrNlyxxRvWW5fjKd3bcLHPxofWuCjaeZg=="
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-5.0.0.tgz",
+      "integrity": "sha512-bAEm2fx8Dq/a35Z6PIRkkBBJvR56BbEJvhpNtvCZ4W9FyORSna77fn+xtYFjqk5JpBS+fMnAOG/wFgkQBmB7hw=="
     },
     "npm-run-path": {
       "version": "2.0.2",
@@ -10461,6 +10461,13 @@
         "normalize-url": "^3.0.0",
         "postcss": "^7.0.0",
         "postcss-value-parser": "^3.0.0"
+      },
+      "dependencies": {
+        "normalize-url": {
+          "version": "3.3.0",
+          "resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-3.3.0.tgz",
+          "integrity": "sha512-U+JJi7duF1o+u2pynbp2zXDW2/PADgC30f0GsHZtRh+HOcXHnw137TrNlyxxRvWW5fjKd3bcLHPxofWuCjaeZg=="
+        }
       }
     },
     "postcss-normalize-whitespace": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1040,9 +1040,9 @@
       "integrity": "sha512-1dVNHT76Uu5N3eJNTYcvxee+jzX4Z9lfciqRRHCU27ihbUcYi+iSc2iml5Ke1LXe1SyJCLA0+14Jh4tXJgOppA=="
     },
     "@hapi/hoek": {
-      "version": "8.5.0",
-      "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-8.5.0.tgz",
-      "integrity": "sha512-7XYT10CZfPsH7j9F1Jmg1+d0ezOux2oM2GfArAzLwWe4mE2Dr3hVjsAL6+TFY49RRJlCdJDMw3nJsLFroTc8Kw=="
+      "version": "8.5.1",
+      "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-8.5.1.tgz",
+      "integrity": "sha512-yN7kbciD87WzLGc5539Tn0sApjyiGHAJgKvG9W8C7O+6c7qmoQMfVs0W4bX17eqz6C78QJqqFrtgdK5EWf6Qow=="
     },
     "@hapi/joi": {
       "version": "15.1.1",

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "gravatar": "^1.8.0",
     "jsonwebtoken": "^8.5.1",
     "mongoose": "^5.8.10",
+    "normalize-url": "^5.0.0",
     "request": "^2.88.0"
   },
   "devDependencies": {

--- a/routes/api/profile.js
+++ b/routes/api/profile.js
@@ -52,43 +52,42 @@ router.post(
     if (!errors.isEmpty()) {
       return res.status(400).json({ errors: errors.array() });
     }
+    const {
+      company,
+      location,
+      website,
+      bio,
+      skills,
+      status,
+      githubusername,
+      youtube,
+      twitter,
+      instagram,
+      linkedin,
+      facebook
+    } = req.body;
 
-    // Build profile object
-    const mainFields = [
-      'company',
-      'location',
-      'bio',
-      'status',
-      'githubusername'
-    ];
-
-    // build the main fields
-    const profileFields = mainFields.reduce(
-      (acc, field) => {
-        if (req.body[field]) acc[field] = req.body[field];
-        return acc;
-      },
-      { user: req.user.id } // initial object
-    );
-
-    const { website, skills } = req.body;
-    // add website and skills
-    if (website)
-      profileFields.website = normalize(req.body.website, { forceHttps: true });
-    if (skills && typeof skills === 'string')
-      profileFields.skills = req.body.skills
-        .split(',')
-        .map(skill => skill.trim());
-    else if (Array.isArray(skills)) profileFields.skills = skills;
+    const profileFields = {
+      user: req.user.id,
+      company,
+      location,
+      website: website === '' ? '' : normalize(website, { forceHttps: true }),
+      bio,
+      skills: Array.isArray(skills)
+        ? skills
+        : skills.split(',').map(skill => ' ' + skill.trim()),
+      status,
+      githubusername
+    };
 
     // Build social object and add to profileFields
-    const socialfields = ['youtube', 'twitter', 'instagram', 'linkedin'];
+    const socialfields = { youtube, twitter, instagram, linkedin, facebook };
 
-    profileFields.social = socialfields.reduce((acc, field) => {
-      if (req.body[field])
-        acc[field] = normalize(req.body[field], { forceHttps: true });
-      return acc;
-    }, {});
+    for (const [key, value] of Object.entries(socialfields)) {
+      if (value.length > 0)
+        socialfields[key] = normalize(value, { forceHttps: true });
+    }
+    profileFields.social = socialfields;
 
     try {
       // Using upsert option (creates new doc if no match is found):

--- a/routes/api/profile.js
+++ b/routes/api/profile.js
@@ -71,14 +71,14 @@ router.post(
       { user: req.user.id } // initial object
     );
 
+    const { website, skills } = req.body;
     // add website and skills
-    if (req.body.website)
+    if (website)
       profileFields.website = normalize(req.body.website, { forceHttps: true });
-    console.log('skills', req.body.skills);
-    // if (req.body.skills)
-    //   profileFields.skills = req.body.skills
-    //     .split(',')
-    //     .map(skill => skill.trim());
+    if (skills)
+      profileFields.skills = req.body.skills
+        .split(',')
+        .map(skill => skill.trim());
 
     // Build social object and add to profileFields
     const socialfields = ['youtube', 'twitter', 'instagram', 'linkedin'];

--- a/routes/api/profile.js
+++ b/routes/api/profile.js
@@ -75,10 +75,11 @@ router.post(
     // add website and skills
     if (website)
       profileFields.website = normalize(req.body.website, { forceHttps: true });
-    if (skills)
+    if (skills && typeof skills === 'string')
       profileFields.skills = req.body.skills
         .split(',')
         .map(skill => skill.trim());
+    else if (Array.isArray(skills)) profileFields.skills = skills;
 
     // Build social object and add to profileFields
     const socialfields = ['youtube', 'twitter', 'instagram', 'linkedin'];

--- a/routes/api/profile.js
+++ b/routes/api/profile.js
@@ -73,9 +73,12 @@ router.post(
 
     // add website and skills
     if (req.body.website)
-      profileFields.website = normalize(website, { forceHttps: true });
-    if (req.body.skills)
-      profileFields.skills = skills.split(',').map(skill => skill.trim());
+      profileFields.website = normalize(req.body.website, { forceHttps: true });
+    console.log('skills', req.body.skills);
+    // if (req.body.skills)
+    //   profileFields.skills = req.body.skills
+    //     .split(',')
+    //     .map(skill => skill.trim());
 
     // Build social object and add to profileFields
     const socialfields = ['youtube', 'twitter', 'instagram', 'linkedin'];


### PR DESCRIPTION
Currently if a user adds a social URL or website URL when setting or editing a profile, the validity of the URL depends on the user entering a a valid full path URL. This PR brings in [normalize-url](https://www.npmjs.com/package/normalize-url) to provide a full path URL regardless of what the user has entered, which will open correctly from the client when clicked.

Additionally this PR fixes the case for skills being an array and not a string.
Currently after setting up a profile the client sends a string of csv's to the backend which are then split into an array to be added to the document. However on editing a profile in the client an array is sent to the backend but there is no case to handle an array, only a string so we get an error of 
`UnhandledPromiseRejectionWarning: TypeError: skills.split is not a function`

I'll understand if you don't wish to merge this PR as bringing in normalize-url is not in the course, but I have mentioned it a couple of times in the course Q&A as a solution for students.
It's a very simple package though, so no major change.