### PR TITLE
Take localStorage out of reducers

### DIFF
--- a/client/src/App.js
+++ b/client/src/App.js
@@ -12,13 +12,12 @@ import setAuthToken from './utils/setAuthToken';
 
 import './App.css';
 
-if (localStorage.token) {
-  setAuthToken(localStorage.token);
-}
-
 const App = () => {
   useEffect(() => {
-    store.dispatch(loadUser());
+    if (localStorage.token) {
+      setAuthToken(localStorage.token);
+      store.dispatch(loadUser());
+    }
   }, []);
 
   return (
@@ -27,7 +26,7 @@ const App = () => {
         <Fragment>
           <Navbar />
           <Switch>
-            <Route exact path='/' component={Landing} />
+            <Route exact path="/" component={Landing} />
             <Route component={Routes} />
           </Switch>
         </Fragment>

--- a/client/src/reducers/auth.js
+++ b/client/src/reducers/auth.js
@@ -28,7 +28,6 @@ export default function(state = initialState, action) {
         user: payload
       };
     case REGISTER_SUCCESS:
-      localStorage.setItem('token', payload.token);
       return {
         ...state,
         ...payload,
@@ -36,7 +35,6 @@ export default function(state = initialState, action) {
         loading: false
       };
     case LOGIN_SUCCESS:
-      localStorage.setItem('token', payload.token);
       return {
         ...state,
         ...payload,
@@ -44,7 +42,6 @@ export default function(state = initialState, action) {
         loading: false
       };
     case ACCOUNT_DELETED:
-      localStorage.removeItem('token');
       return {
         ...state,
         token: null,
@@ -53,7 +50,6 @@ export default function(state = initialState, action) {
         user: null
       };
     case LOGOUT:
-      localStorage.removeItem('token');
       return {
         ...state,
         token: null,

--- a/client/src/store.js
+++ b/client/src/store.js
@@ -18,10 +18,10 @@ const store = createStore(
 let currentState;
 
 store.subscribe(() => {
+  // keep track of the previous and current state to compare changes
   let previousState = currentState;
   currentState = store.getState();
-  console.log('previous state', previousState);
-  console.log('current state', currentState);
+  // if the token changes set the value in localStorage
   if (previousState.auth.token !== currentState.auth.token) {
     localStorage.setItem('token', currentState.auth.token);
   }

--- a/client/src/store.js
+++ b/client/src/store.js
@@ -24,7 +24,10 @@ store.subscribe(() => {
   currentState = store.getState();
   // if the token changes set the value in localStorage
   if (previousState && previousState.auth.token !== currentState.auth.token) {
-    localStorage.setItem('token', currentState.auth.token);
+    const token = currentState.auth.token;
+    token
+      ? localStorage.setItem('token', token)
+      : localStorage.removeItem('token');
   }
 });
 

--- a/client/src/store.js
+++ b/client/src/store.js
@@ -13,4 +13,18 @@ const store = createStore(
   composeWithDevTools(applyMiddleware(...middleware))
 );
 
+// set up a store subscription listener
+
+let currentState;
+
+store.subscribe(() => {
+  let previousState = currentState;
+  currentState = store.getState();
+  console.log('previous state', previousState);
+  console.log('current state', currentState);
+  if (previousState.auth.token !== currentState.auth.token) {
+    localStorage.setItem('token', currentState.auth.token);
+  }
+});
+
 export default store;

--- a/client/src/store.js
+++ b/client/src/store.js
@@ -14,6 +14,7 @@ const store = createStore(
 );
 
 // set up a store subscription listener
+// to store the users token in localStorage
 
 let currentState;
 
@@ -22,7 +23,7 @@ store.subscribe(() => {
   let previousState = currentState;
   currentState = store.getState();
   // if the token changes set the value in localStorage
-  if (previousState.auth.token !== currentState.auth.token) {
+  if (previousState && previousState.auth.token !== currentState.auth.token) {
     localStorage.setItem('token', currentState.auth.token);
   }
 });


### PR DESCRIPTION
This PR addresses issues with local storage of a users token being managed in the auth reducer.
According to [redux docs](https://redux.js.org/basics/reducers/#handling-actions), our reducers should be kept pure and not have any side effects.
![Screenshot_2020-02-20_12-14-52](https://user-images.githubusercontent.com/21976188/74933445-dda8ec80-53db-11ea-9ac4-404479ac31e1.png)
I would merge this myself but I'm wary of too many abstractions away from the course content and potentially confusing students as to best practices.