### PR TITLE
Removed "extended: false" option

### DIFF
--- a/server.js
+++ b/server.js
@@ -8,7 +8,7 @@ const app = express();
 connectDB();
 
 // Init Middleware
-app.use(express.json({ extended: false }));
+app.use(express.json());
 
 // Define Routes
 app.use('/api/users', require('./routes/api/users'));


### PR DESCRIPTION
Removed "extended: false" option from the express.json() call. This is an invalid option for expression.json() per Express.js documentation.