### PR TITLE
handle social fields error

### DIFF
--- a/routes/api/profile.js
+++ b/routes/api/profile.js
@@ -85,7 +85,7 @@ router.post(
     const socialfields = { youtube, twitter, instagram, linkedin, facebook };
 
     for (const [key, value] of Object.entries(socialfields)) {
-      if (value.length > 0)
+      if (value && value.length > 0)
         socialfields[key] = normalize(value, { forceHttps: true });
     }
     profileFields.social = socialfields;


### PR DESCRIPTION
When requesting this path in postman it resolved in this error. 

```
[0] (node:6092) UnhandledPromiseRejectionWarning: TypeError: Cannot read property 'length' of undefined
[0]     at C:\Users\lulu\Desktop\devconnector_2.0-master\devconnector_2.0-master\routes\api\profile.js:84:17
[0]     at Layer.handle [as handle_request] (C:\Users\lulu\Desktop\devconnector_2.0-master\devconnector_2.0-master\node_modules\express\lib\router\layer.js:95:5)
[0]     at next (C:\Users\lulu\Desktop\devconnector_2.0-master\devconnector_2.0-master\node_modules\express\lib\router\route.js:137:13)     
[0]     at middleware (C:\Users\lulu\Desktop\devconnector_2.0-master\devconnector_2.0-master\node_modules\express-validator\src\middlewares\check.js:15:13)
[0]     at processTicksAndRejections (internal/process/task_queues.js:97:5)
[0] (node:6092) UnhandledPromiseRejectionWarning: Unhandled promise rejection. This error originated either by throwing inside of an async function without a catch block, or by rejecting a promise which was not handled with .catch(). To terminate the node process on unhandled promise rejection, use the CLI flag `--unhandled-rejections=strict` (see https://nodejs.org/api/cli.html#cli_unhandled_rejections_mode). (rejection id: 1)
[0] (node:6092) [DEP0018] DeprecationWarning: Unhandled promise rejections are deprecated. In the future, promise rejections that are not handled will terminate the Node.js process with a non-zero exit code.
```