### PR TITLE
Change the createProfile call in the ProfileForm component to handle …

### DIFF
--- a/client/src/components/profile-forms/ProfileForm.js
+++ b/client/src/components/profile-forms/ProfileForm.js
@@ -65,7 +65,7 @@ const ProfileForm = ({
 
   const onSubmit = (e) => {
     e.preventDefault();
-    createProfile(formData, history, true);
+    createProfile(formData, history, profile ? true : false);
   };
 
   return (


### PR DESCRIPTION
…edit vs creation user flows. Closes #102.

The ProfileForm component handles both profile creation and profile update flows. Currently in the createProfile call, the 'edit' Boolean parameter is hard-coded to 'true'.

This causes:
- The success alert to always have the text "Profile updated". If a user is creating a profile for the first time, this should be "Profile created".
- The redirect behavior to always leave the user on the ProfileForm component after a successful submission. The intended behavior is that newly created profile submissions will have the user redirected to the dashboard.

My fix is very simple, replace the hard-coded 'true' parameter with a ternary operation based on the state of the profile variable. If a user is creating a new profile, this variable will be null. if the user is editing their existing profile, the profile variable will have their exiting profile object referenced by the profile variable.

I have added a couple screenshots to show this working for new profile creations:
![Screenshot from 2020-04-16 10-30-49](https://user-images.githubusercontent.com/4755594/79482140-9ef37500-7fcd-11ea-9edf-0c78224483a4.png)
![Screenshot from 2020-04-16 10-32-35](https://user-images.githubusercontent.com/4755594/79482143-9f8c0b80-7fcd-11ea-8f3a-16077ce2ebf8.png)


Signed-off-by: Ryan Parmeter <parkingmeter@gmail.com>