### PR TITLE
Remove unnecessary check in ProfileGithub

### DIFF
--- a/client/src/components/profile/ProfileGithub.js
+++ b/client/src/components/profile/ProfileGithub.js
@@ -12,37 +12,29 @@ const ProfileGithub = ({ username, getGithubRepos, repos }) => {
   return (
     <div className="profile-github">
       <h2 className="text-primary my-1">Github Repos</h2>
-      {repos === null ? (
-        <Spinner />
-      ) : (
-        repos.map(repo => (
-          <div key={repo.id} className="repo bg-white p-1 my-1">
-            <div>
-              <h4>
-                <a
-                  href={repo.html_url}
-                  target="_blank"
-                  rel="noopener noreferrer"
-                >
-                  {repo.name}
-                </a>
-              </h4>
-              <p>{repo.description}</p>
-            </div>
-            <div>
-              <ul>
-                <li className="badge badge-primary">
-                  Stars: {repo.stargazers_count}
-                </li>
-                <li className="badge badge-dark">
-                  Watchers: {repo.watchers_count}
-                </li>
-                <li className="badge badge-light">Forks: {repo.forks_count}</li>
-              </ul>
-            </div>
+      {repos.map(repo => (
+        <div key={repo.id} className="repo bg-white p-1 my-1">
+          <div>
+            <h4>
+              <a href={repo.html_url} target="_blank" rel="noopener noreferrer">
+                {repo.name}
+              </a>
+            </h4>
+            <p>{repo.description}</p>
           </div>
-        ))
-      )}
+          <div>
+            <ul>
+              <li className="badge badge-primary">
+                Stars: {repo.stargazers_count}
+              </li>
+              <li className="badge badge-dark">
+                Watchers: {repo.watchers_count}
+              </li>
+              <li className="badge badge-light">Forks: {repo.forks_count}</li>
+            </ul>
+          </div>
+        </div>
+      ))}
     </div>
   );
 };


### PR DESCRIPTION
Udemy student (credit: _**Sherwin**_) brought up the fact that `repos` is never `null`. It's either an empty array or a non-empty array.

I think we can get rid of this null-checking condition. If the array is empty, then there just won't be any repos that are displayed.

https://www.udemy.com/course/mern-stack-front-to-back/learn/lecture/10055418#questions/10757504