### PR TITLE
Fix issue fetching github repositories by username

### DIFF
--- a/routes/api/profile.js
+++ b/routes/api/profile.js
@@ -321,7 +321,7 @@ router.get('/github/:username', async (req, res) => {
       Authorization: `token ${config.get('githubToken')}`
     };
 
-    const gitHubResponse = await axios.get(uri, { headers });
+    const gitHubResponse = await axios.get(uri, headers);
     return res.json(gitHubResponse.data);
   } catch (err) {
     console.error(err.message);


### PR DESCRIPTION
The headers object needs to be passed directly in axios.get instead of passing it inside curly braces.
Making this change will fix the issue of 'Request failed with status code 401' error message