### PR TITLE
Update profile.js

### DIFF
--- a/routes/api/profile.js
+++ b/routes/api/profile.js
@@ -68,7 +68,7 @@ router.post(
       user: req.user.id,
       company,
       location,
-      website: website === '' ? '' : normalize(website, { forceHttps: true }),
+      website: website && website !== '' ? normalize(website, { forceHttps: true }) : '',
       bio,
       skills: Array.isArray(skills)
         ? skills


### PR DESCRIPTION
When the request object doesn't have the 'website' field, the normalize gives an error. So this code will normalize 'website' only when it is defined and not empty.