### PR TITLE
Handling "delete comment" errors

### DIFF
--- a/routes/api/posts.js
+++ b/routes/api/posts.js
@@ -188,9 +188,14 @@ router.post(
 // @route    DELETE api/posts/comment/:id/:comment_id
 // @desc     Delete comment
 // @access   Private
-router.delete('/comment/:id/:comment_id', auth, async (req, res) => {
+router.delete('/comment/:id/:comment_id', [auth, checkObjectId('id')], async (req, res) => {
   try {
     const post = await Post.findById(req.params.id);
+    
+    // Check if post exists     
+    if (!post) {
+      return res.status(404).json({ msg: 'Post not found' });
+    }
 
     // Pull out comment
     const comment = post.comments.find(


### PR DESCRIPTION
1. Adding "checkObjectId" middleware to check for post id (because if user send an invalid id (ObjectId) we will get a server error)
2. Check if post exists