### PR TITLE
Include all default fields when upserting new profile

### DIFF
--- a/routes/api/profile.js
+++ b/routes/api/profile.js
@@ -91,7 +91,7 @@ router.post(
       let profile = await Profile.findOneAndUpdate(
         { user: req.user.id },
         { $set: profileFields },
-        { new: true, upsert: true }
+        { new: true, upsert: true, setDefaultsOnInsert: true }
       );
       res.json(profile);
     } catch (err) {


### PR DESCRIPTION
When creating a new profile, the `upsert` option takes care of inserting the new profile into the database if it doesn't exist. However, if the user doesn't supply every field, Mongoose won't populate them prior to adding the profile. In particular, the profile's `date` field isn't populated. This can cause some confusion when users notice that the `date` field in their retrieved profile object appears to be constantly updating (when viewed on the front-end).

To fix this, add the `setDefaultsOnInsert` option to `true` inside the `findOneAndUpdate` call. This will include all missing, default fields when creating a profile.

Credit: Dongju (from **[Udemy](https://www.udemy.com/course/mern-stack-front-to-back/learn/lecture/10055374#questions/12348962/&utm_campaign=email&utm_source=sendgrid.com&utm_medium=email)**)

Helpful StackOverflow: https://stackoverflow.com/questions/25755521/mongoose-upsert-does-not-create-default-schema-property