### PR TITLE
preloader added for homepage issue

### DIFF
--- a/client/src/App.js
+++ b/client/src/App.js
@@ -4,6 +4,7 @@ import Navbar from './components/layout/Navbar';
 import Landing from './components/layout/Landing';
 import Routes from './components/routing/Routes';
 import { LOGOUT } from './actions/types';
+import AuthRoutes from './components/routing/AuthRoutes';
 
 // Redux
 import { Provider } from 'react-redux';
@@ -33,7 +34,7 @@ const App = () => {
         <Fragment>
           <Navbar />
           <Switch>
-            <Route exact path="/" component={Landing} />
+            <AuthRoutes exact path="/" component={Landing} />
             <Route component={Routes} />
           </Switch>
         </Fragment>

--- a/client/src/components/routing/AuthRoutes.js
+++ b/client/src/components/routing/AuthRoutes.js
@@ -1,0 +1,37 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { connect } from 'react-redux';
+import { Route, Redirect } from 'react-router-dom';
+import Spinner from '../layout/Spinner';
+
+const AuthRoutes = ({
+    component: Component,
+    auth: { isAuthenticated },
+    ...rest
+}) => {
+    return (
+        <Route 
+            {...rest}
+            render={props => 
+                localStorage.getItem('token') === null ? (
+                    <Component {...props} /> 
+                ) : !isAuthenticated ? (
+                    <Spinner />
+                ) : (
+                    <Redirect to='/dashboard' />
+                )
+            }
+        />
+    )
+}
+
+AuthRoutes.propTypes = {
+    auth: PropTypes.object.isRequired
+}
+
+const mapStateToProps = state => ({
+    auth: state.auth
+}) 
+
+
+export default connect(mapStateToProps)(AuthRoutes)

--- a/client/src/components/routing/Routes.js
+++ b/client/src/components/routing/Routes.js
@@ -13,14 +13,15 @@ import Posts from '../posts/Posts';
 import Post from '../post/Post';
 import NotFound from '../layout/NotFound';
 import PrivateRoute from '../routing/PrivateRoute';
+import AuthRoutes from './AuthRoutes';
 
 const Routes = props => {
   return (
     <section className="container">
       <Alert />
       <Switch>
-        <Route exact path="/register" component={Register} />
-        <Route exact path="/login" component={Login} />
+        <AuthRoutes exact path="/register" component={Register} />
+        <AuthRoutes exact path="/login" component={Login} />
         <Route exact path="/profiles" component={Profiles} />
         <Route exact path="/profile/:id" component={Profile} />
         <PrivateRoute exact path="/dashboard" component={Dashboard} />


### PR DESCRIPTION
So what I did is made a AuthRoutes.js file in which it first checks for the token in local storage. If token is not there the user is redirected to the login page otherwise it further checks the redux store for the isAuthenicated state. Then Spinner Component is rendered until the isAuthenticated is false and when the user is authenticated and the state is true the user redirected to the '/dashboard' route.
So is AuthRoutes is only for the '/', '/login' and '/register' routes and not for '/profile' route. 