### PR TITLE
Fixing Frontend login error (401)

### DIFF
--- a/client/src/reducers/auth.js
+++ b/client/src/reducers/auth.js
@@ -35,6 +35,7 @@ export default function (state = initialState, action) {
         loading: false
       };
     case LOGIN_SUCCESS:
+      localStorage.setItem('token', action.payload.token);
       return {
         ...state,
         ...payload,


### PR DESCRIPTION
Problem: After sing up, when user login.  token doesn't get saved to browser local storage in order to loadUser()