### PR TITLE
findByIdAndRemove() instead of findOneAndRemove()

### DIFF
--- a/routes/api/profile.js
+++ b/routes/api/profile.js
@@ -144,7 +144,7 @@ router.delete('/', auth, async (req, res) => {
     await Promise.all([
       Post.deleteMany({ user: req.user.id }),
       Profile.findOneAndRemove({ user: req.user.id }),
-      User.findOneAndRemove({ _id: req.user.id })
+      User.findByIdAndRemove(req.user.id)
     ]);
 
     res.json({ msg: 'User deleted' });


### PR DESCRIPTION
since we are directly removing a document from the UserModel by id, no need for {_id:req.user.id}.