### PR TITLE
Simplify import path for PrivateRoute

### DIFF
--- a/client/src/components/routing/Routes.js
+++ b/client/src/components/routing/Routes.js
@@ -12,9 +12,9 @@ import Profile from '../profile/Profile';
 import Posts from '../posts/Posts';
 import Post from '../post/Post';
 import NotFound from '../layout/NotFound';
-import PrivateRoute from '../routing/PrivateRoute';
+import PrivateRoute from './PrivateRoute';
 
-const Routes = props => {
+const Routes = (props) => {
   return (
     <section className="container">
       <Alert />

--- a/client/src/components/routing/Routes.js
+++ b/client/src/components/routing/Routes.js
@@ -14,7 +14,7 @@ import Post from '../post/Post';
 import NotFound from '../layout/NotFound';
 import PrivateRoute from './PrivateRoute';
 
-const Routes = (props) => {
+const Routes = props => {
   return (
     <section className="container">
       <Alert />


### PR DESCRIPTION
Instead of going up one folder and then back in to the same folder, the path now points to the file in the same folder.